### PR TITLE
prerequisites: cleanup script

### DIFF
--- a/Satellite Guide Documents/README.md
+++ b/Satellite Guide Documents/README.md
@@ -50,9 +50,7 @@ The proposed model requires virtual machines provisioned on cloud providers and/
 
 *Note: the scripts and components are tested in versions mentioned in the brackets, usually it should work well in higher version as well.*
 
-1. Ubuntu Linux (20.04.4 LTS (Focal Fossa))
-1. Docker (v20.10.14)
-1. Docker-compose (version 1.24.0)
+1. A recent Debian-based GNU/Linux distribution (testen on Debian 11 / Bullseye and Ubuntu Linux 20.04.4 LTS / Focal Fossa)
 1. Create/Update rights to your DNS service to manage satellite URLs in DNS
 1. SSL certificates of your domain for applications (applications by default use HTTPS so having certificates on hand is required. You may also use free Letsencrypt certificates, please refer to its website on how to get them)
 1. JWT signing certificate –
@@ -157,13 +155,13 @@ Open app-mw-config-template.yaml in the text editor, configure password in explo
 
 ```yaml
 explorerDb:
-    postgresql://hppoc:password@explorerdb:5432/fabricexplorer?sslmode=disable
+  postgresql://hppoc:password@explorerdb:5432/fabricexplorer?sslmode=disable
 ```
 
 ### Steps to configure password for Application middleware postgres DB
 
 ```sh
- cd iSHARESatellite/templates
+cd iSHARESatellite/templates
 ```
 
 Open docker-compose-mw-template.yaml in a text editor and look for below snippet:
@@ -183,7 +181,8 @@ Open hlf-mw-config-template.yaml file in a text editor and look for the below sn
 
 ```yaml
 ishareConfig:
-    middlewareConfig:
+  middlewareConfig:
+    type: satellite
     postgres_connection_url: postgresql://admin:adminpw@app-postgres:5432/ishare?sslmode=disable
 ```
 
@@ -193,9 +192,9 @@ Open app-mw-config-template.yaml file in a text editor and look for the below sn
 
 ```yaml
 ishareConfig:
-    middlewareConfig:
-        postgres_connection_url:
-            postgresql://admin:adminpw@app-postgres:5432/ishare?sslmode=disable
+  middlewareConfig:
+    postgres_connection_url:
+      postgresql://admin:adminpw@app-postgres:5432/ishare?sslmode=disable
 ```
 
 Change the password `adminpw` in connection string with password configured in `docker-compose-mw.yaml`.
@@ -264,8 +263,9 @@ To install and ensure all the necessary packages are available in the system, us
 
 ```sh
 bash prerequisites.sh
-cd scripts
 ```
+
+If docker was not already setup and configured for the current user, logout and login before continuing.
 
 Configure environment variables to initialize scripts. See env variables with example below:
 
@@ -279,6 +279,7 @@ Configure environment variables to initialize scripts. See env variables with ex
 export ORG_NAME=newsatellite
 export SUB_DOMAIN=test.example.com
 export ENVIRONMENT=test
+cd scripts
 ```
 
 To generate HLF fabric ca certs, use the below command :

--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -1,85 +1,41 @@
-#! /bin/sh
+#!/bin/sh
 
-#Docker check and installations
-IsDockerInstalledAlready=false
-if which docker && docker --version && docker-compose --version; then
-  echo "Docker is already installed"
-  IsDockerInstalledAlready=true
+# Stop on failures
+set -e
+
+# Update package lists
+echo "Updating package list"
+sudo apt-get update
+
+# Note that already installed packages will be ignored
+echo "Installing packages"
+sudo apt-get install -y docker.io docker-compose curl jq openssl
+
+# Configured user groups includes docker?
+if id -Gn "$USER" | grep -q '\bdocker\b'; then
+    echo "Current user '$USER' already part of 'docker' group"
 else
-  echo "Install docker and docker-compose"
-
-sudo apt-get update ||  { echo 'update existing list of packages failed' ; exit 1; }
-
-sudo apt install apt-transport-https ca-certificates curl software-properties-common -y ||  { echo 'installation of prerequisite packages which let apt use packages over HTTPS failed' ; exit 1; }
-
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add - ||  { echo 'add the GPG key for the official Docker repository to your system failed' ; exit 1; }
-
-sudo apt-key fingerprint 0EBFCD88 ||  { echo 'Adding fingerprint failed' ; exit 1; }
-
-sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-   $(lsb_release -cs) \
-   stable" ||  { echo 'Adding Docker repository to APT sources failed' ; exit 1; }
-
-sudo apt-get update -y || { echo 'update the package database with the Docker packages failed' ; exit 1; }
-
-sudo apt-get install docker-ce docker-ce-cli containerd.io ||  { echo 'Downloading docker-ce adn docker-ce-cli failed' ; exit 1; }
-
-sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose ||  { echo 'Downloading of docker-compose failed' ; exit 1; }
-
-sudo chmod +x /usr/local/bin/docker-compose ||  { echo 'Moving file to root location failed' ; exit 1; }
-
-sudo gpasswd -a $USER docker ||  { echo 'Adding Docker user failed' ; exit 1; }
-
-docker version ;
+    echo "Adding current user '$USER' to the 'docker' group"
+    sudo gpasswd -a "$USER" docker
 fi
 
-#Check jq and install
-
-if jq --version; then
-  echo "jq is already installed"
+# Installation of HLF Binaries
+if [ -f "bin/fabric-ca-server" ] && [ -f "config/configtx.yaml" ]; then
+    echo "HLF binaries already installed"
 else
-  echo "jq does not exist. Install jq"
-sudo apt update ||  { echo 'update existing list of packages failed' ; exit 1; }
-
-sudo apt install -y jq ||  { echo 'Installing of jq failed' ; exit 1; }
+    echo "Installing HLF binaries"
+    curl https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/bootstrap.sh \
+        | bash -s -- 2.2.0 1.4.8 -d -s
 fi
 
-#Installation of HLF Binaries
-
-if [ -d "bin" ] && [ -d "config"  ] ;
-then
-    echo "Directory bin and config exists."  ||  { echo 'Binaries files already exist' ; exit 1; }
+# Currently logged in user session includes docker group?
+if id -Gn | grep -q '\bdocker\b'; then
+    echo "Prerequisites installed!"
 else
-    echo "Error: Directory bin and config does not exists."
-curl https://raw.githubusercontent.com/hyperledger/fabric/master/scripts/bootstrap.sh | bash -s -- 2.2.0 1.4.8 -d -s
-fi
-
-
-#Check and install openssl
-
-if openssl version; then
-  echo "openssl is installed"
-else
-  echo "Install openssl"
-sudo apt update ||  { echo 'update existing list of packages failed' ; exit 1; }
-
-sudo apt install build-essential checkinstall zlib1g-dev -y ||  { echo 'install build-essential failed' ; exit 1; }
-cd /usr/local/src/ ;
-wget https://www.openssl.org/source/openssl-1.1.1k.tar.gz ||  { echo 'wget openssl failed' ; exit 1; }
-tar -xf openssl-1.1.1k.tar.gz ||  { echo 'Extracting openssl tar file failed' ; exit 1; }
-cd openssl-1.1.1k.tar.gz;
-openssl version ||  { echo 'check opensslversion failed' ; exit 1; }
-sudo ./config --prefix=/us3r/local/ssl --openssldir=/usr/local/ssl shared zlib ||  { echo 'configure and compile OpenSSL failed' ; exit 1; }
-sudo make ||  { echo 'make command failed' ; exit 1; }
-sudo make test;
-sudo make install;
-fi
-
-if [[ ${IsDockerInstalledAlready} = false ]]; then 
     cat <<EOF
-**
-** Reboot to complete the installation of docker before proceeding
-**
+
+*
+* Logout and in again to complete the installation of docker before proceeding.
+*
 EOF
 fi

--- a/templates/docker-compose-mw-template.yaml
+++ b/templates/docker-compose-mw-template.yaml
@@ -4,7 +4,7 @@ networks:
   net:
     name: fabric_network
 services:
- offchain_sat:
+  offchain_sat:
     image: postgres:13.0-alpine
     container_name: offchain_sat
     restart: always


### PR DESCRIPTION
Use stock docker and docker-compose.  Do not try and compile openssl ourselves.  Do not require a reboot but simply ensure user is added to docker group and that change is already effective in shell session.

And fix some indentations.